### PR TITLE
Change the link to an image

### DIFF
--- a/public/softwarex-illustrative-example.html
+++ b/public/softwarex-illustrative-example.html
@@ -31,7 +31,7 @@
       When opening the SLAM demo page, a succint dialog asks for a file and a reading profile. Select the generated EEG file in the ADF format, <code>generated.adf</code>, and the toy profile A.
     </p>
     <figure class="fullwidth">
-      <img src="/images/open-1.png"
+      <img src="images/open-1.png"
             alt="SLAM page with 3 controls: a file chooser button, a profile selector box, and an Open button">
       </img>
       <figcaption>Select the generated file with toy profile A in SLAM</figcaption>


### PR DESCRIPTION
Github pages puts the pages as a sub-path. Loading /images does not work, because the path starts with /slam/. This was not detected locally because the local deployment does not have a root path component, so /images and ./images is the same path component.